### PR TITLE
Replace delay in measure for faster response time.

### DIFF
--- a/Bme280BoschWrapper.cpp
+++ b/Bme280BoschWrapper.cpp
@@ -56,7 +56,7 @@ bool Bme280BoschWrapper::measure()
       else{
         SPIRead(bme280.dev_id, 0xF3, &reg_data, 1);
       }
-      if(reg_data & 0x08){
+      if(!(reg_data & 0x08)){
         break;
       }
       bme280.delay_ms(1);

--- a/Bme280BoschWrapper.cpp
+++ b/Bme280BoschWrapper.cpp
@@ -49,10 +49,18 @@ bool Bme280BoschWrapper::measure()
   if(forced)
   {
     setSensorSettings();
-    while(reg_data & 0x08){ 
-      I2CRead(bme280.dev_id, 0xF3, &reg_data, 1);
-     bme280.delay_ms(1);
-    }
+    for(uint8_t i=0;i<255;i++){
+      if(bme280.intf == BME280_I2C_INTF){
+        I2CRead(bme280.dev_id, 0xF3, &reg_data, 1); 
+      }
+      else{
+        SPIRead(bme280.dev_id, 0xF3, &reg_data, 1);
+      }
+      if(reg_data & 0x08){
+        break;
+      }
+      bme280.delay_ms(1);
+    }     
     ret += bme280_get_sensor_data(BME280_PRESS | BME280_HUM | BME280_TEMP, &comp_data, &bme280);
   }
   else

--- a/Bme280BoschWrapper.cpp
+++ b/Bme280BoschWrapper.cpp
@@ -44,11 +44,15 @@ bool Bme280BoschWrapper::beginSPI(int8_t cspin)
 bool Bme280BoschWrapper::measure()
 {
   int8_t ret = BME280_OK;
+  uint8_t reg_data=0x08;
 
   if(forced)
   {
     setSensorSettings();
-    bme280.delay_ms(255);
+    while(reg_data & 0x08){ 
+      I2CRead(bme280.dev_id, 0xF3, &reg_data, 1);
+     bme280.delay_ms(1);
+    }
     ret += bme280_get_sensor_data(BME280_PRESS | BME280_HUM | BME280_TEMP, &comp_data, &bme280);
   }
   else


### PR DESCRIPTION
Got the method for this from the adafruit library. 

Instead of delaying for 255ms this will return as soon as a new measurement is ready to read. 

In my testing this takes only 26ms on average instead of waiting 255ms.

Edit: Updated the code to prevent possible endless loop and included SPI usage, also reduced the read time to ~18ms in my testing.